### PR TITLE
Initial version of binary writer

### DIFF
--- a/XamlCompiler.Tests/ObjectInfoTests.cs
+++ b/XamlCompiler.Tests/ObjectInfoTests.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+using Mono.Cecil.Rocks;
+using XamlCompiler.Compiler;
+using Xunit;
+
+namespace XamlCompiler.Tests
+{
+    public class ObjectInfoTests
+    {
+        private static TypeDefinition CheckTypeCreation(string @namespace, string @class)
+        {
+            var typeName = string.IsNullOrEmpty(@namespace) ? @class : $"{@namespace}.{@class}";
+            var module = ModuleDefinition.CreateModule("foobar", ModuleKind.Dll);
+            var baseType = module.ImportReference(typeof(object));
+            var objectInfo = new ObjectInfo(baseType) {TypeName = typeName};
+            objectInfo.AddTypeDefinition(module);
+
+            return Assert.Single(module.Types, t => t.Namespace == @namespace && t.Name == @class);
+        }
+
+        [Fact] public void SimpleTypeDefinitionAddedToContext() => CheckTypeCreation("Foo", "Bar");
+        [Fact] public void NamespacelessDefinitionAddedToContext() => CheckTypeCreation("", "Bar");
+        [Fact] public void ComplexNamespaceDefinitionAddedToContext() => CheckTypeCreation("Foo.Baz", "Bar");
+
+        [Fact]
+        public void GeneratedTypeConstructorCallsBaseClassConstructor()
+        {
+            var typeDefinition = CheckTypeCreation("Foo", "Bar");
+            var ctor = Assert.Single(typeDefinition.GetConstructors());
+            var ilProcessor = ctor.Body.GetILProcessor();
+            var baseConstructor = typeDefinition.Module.ImportReference(typeof(object).GetConstructor(new Type[0]));
+
+            Assert.Collection(
+                ilProcessor.Body.Instructions,
+                i => Assert.Equal(OpCodes.Ldarg_0, i.OpCode),
+                i => Assert.Equal(baseConstructor.FullName, ((MethodReference)i.Operand).FullName),
+                i => Assert.Equal(OpCodes.Ret, i.OpCode));
+        }
+    }
+}

--- a/XamlCompiler.Tests/XamlCompilerTest.cs
+++ b/XamlCompiler.Tests/XamlCompilerTest.cs
@@ -1,5 +1,7 @@
 using System;
 using System.IO;
+using System.Linq;
+using System.Reflection;
 using Portable.Xaml;
 using XamlCompiler.Tests.TestClasses;
 using Xunit;
@@ -8,8 +10,50 @@ namespace XamlCompiler.Tests
 {
     public class XamlCompilerTest
     {
+        private static T ActivateInstanceFromXaml<T>(string xaml, string typeName)
+        {
+            var context = new XamlSchemaContext(new[] {typeof(Window).Assembly});
+            using (var xamlReader = new StringReader(xaml))
+            using (var reader = new XamlXmlReader(xamlReader, context))
+            using (var writer = new BinaryXamlWriter(context, "test", new Version()))
+            using (var stream = new MemoryStream())
+            {
+                XamlServices.Transform(reader, writer);
+                var bytes = stream.ToArray();
+                var assembly = Assembly.Load(bytes);
+                var type = assembly.ExportedTypes.Single(t => t.Name == "TestClass");
+                return (T)Activator.CreateInstance(type);
+            }
+        }
+
         [Fact]
-        public void ObjectWriterGeneratesInstanceOfRightType()
+        public void SimpleClassIsDefined()
+        {
+            const string xaml = @"<Window xmlns=""test.fornever.me""
+        xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
+        x:Class=""TestClass"" />";
+
+            var window = ActivateInstanceFromXaml<Window>(xaml, "TestClass");
+            Assert.Equal("TestClass", window.GetType().Name);
+        }
+
+        [Fact]
+        public void PropertiesAreSetFromXaml()
+        {
+            const string xaml = @"<Window xmlns=""test.fornever.me""
+        xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
+        x:Class=""TestClass""
+        StringProperty=""TestString""
+        IntProperty=""42"">
+</Window>";
+
+            var window = ActivateInstanceFromXaml<Window>(xaml, "TestClass");
+            Assert.Equal("TestString", window.StringProperty);
+            Assert.Equal(42, window.IntProperty);
+        }
+
+        [Fact]
+        public void ChildIsCreatedFromXaml()
         {
             const string xaml = @"<Window xmlns=""test.fornever.me""
         xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
@@ -19,14 +63,9 @@ namespace XamlCompiler.Tests
     <Control x:Name=""ChildControl"" />
 </Window>";
 
-            var context = new XamlSchemaContext(new[] {typeof(Window).Assembly});
-            using (var xamlReader = new StringReader(xaml))
-            using (var reader = new XamlXmlReader(xamlReader, context))
-            using (var writer = new XamlObjectWriter(context))
-            {
-                XamlServices.Transform(reader, writer);
-                Assert.Equal(typeof(Window), writer.Result.GetType());
-            }
+            var window = ActivateInstanceFromXaml<Window>(xaml, "TestClass");
+            var child = window.Child;
+            Assert.NotNull(child);
         }
     }
 }

--- a/XamlCompiler.Tests/XamlCompilerTest.cs
+++ b/XamlCompiler.Tests/XamlCompilerTest.cs
@@ -12,10 +12,12 @@ namespace XamlCompiler.Tests
     {
         private static T ActivateInstanceFromXaml<T>(string xaml, string typeName)
         {
-            var context = new XamlSchemaContext(new[] {typeof(Window).Assembly});
+            var referencedAssembly = typeof(T).Assembly;
+            var path = new[] {new Uri(referencedAssembly.CodeBase).LocalPath};
+            var context = new XamlSchemaContext();
             using (var xamlReader = new StringReader(xaml))
             using (var reader = new XamlXmlReader(xamlReader, context))
-            using (var writer = new BinaryXamlWriter(context, "test", new Version()))
+            using (var writer = new BinaryXamlWriter(context, "test", new Version(), path))
             using (var stream = new MemoryStream())
             {
                 XamlServices.Transform(reader, writer);

--- a/XamlCompiler.Tests/XamlCompilerTest.cs
+++ b/XamlCompiler.Tests/XamlCompilerTest.cs
@@ -24,7 +24,7 @@ namespace XamlCompiler.Tests
                 var bytes = stream.ToArray();
                 var assembly = Assembly.Load(bytes);
                 var type = assembly.ExportedTypes.Single(t => t.Name == "TestClass");
-                return (T)Activator.CreateInstance(type);
+                return (T) Activator.CreateInstance(type);
             }
         }
 
@@ -39,7 +39,7 @@ namespace XamlCompiler.Tests
             Assert.Equal("TestClass", window.GetType().Name);
         }
 
-        [Fact]
+        [Fact(Skip = "Not yet implemented")]
         public void PropertiesAreSetFromXaml()
         {
             const string xaml = @"<Window xmlns=""test.fornever.me""
@@ -54,7 +54,7 @@ namespace XamlCompiler.Tests
             Assert.Equal(42, window.IntProperty);
         }
 
-        [Fact]
+        [Fact(Skip = "Not yet implemented")]
         public void ChildIsCreatedFromXaml()
         {
             const string xaml = @"<Window xmlns=""test.fornever.me""

--- a/XamlCompiler.Tests/XamlCompilerTest.cs
+++ b/XamlCompiler.Tests/XamlCompilerTest.cs
@@ -23,7 +23,7 @@ namespace XamlCompiler.Tests
                 writer.WriteAssembly(stream);
                 var bytes = stream.ToArray();
                 var assembly = Assembly.Load(bytes);
-                var type = assembly.ExportedTypes.Single(t => t.Name == "TestClass");
+                var type = assembly.ExportedTypes.Single(t => t.Name == typeName);
                 return (T) Activator.CreateInstance(type);
             }
         }

--- a/XamlCompiler.Tests/XamlCompilerTest.cs
+++ b/XamlCompiler.Tests/XamlCompilerTest.cs
@@ -19,6 +19,8 @@ namespace XamlCompiler.Tests
             using (var stream = new MemoryStream())
             {
                 XamlServices.Transform(reader, writer);
+
+                writer.WriteAssembly(stream);
                 var bytes = stream.ToArray();
                 var assembly = Assembly.Load(bytes);
                 var type = assembly.ExportedTypes.Single(t => t.Name == "TestClass");

--- a/XamlCompiler.Tests/XamlTypeResolverTests.cs
+++ b/XamlCompiler.Tests/XamlTypeResolverTests.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Reflection;
+using Portable.Xaml.Markup;
+using XamlCompiler.Compiler;
+using XamlCompiler.Tests.TestClasses;
+using Xunit;
+
+namespace XamlCompiler.Tests
+{
+    public class XamlTypeResolverTests
+    {
+        [Fact]
+        public void TypeResolverResolvesAType()
+        {
+            var referencedAssembly = typeof(Window).Assembly;
+            var path = new[] {new Uri(referencedAssembly.CodeBase).LocalPath};
+            var resolver = XamlTypeResolver.FromAssemblies(path);
+
+            var attribute = (XmlnsDefinitionAttribute) referencedAssembly.GetCustomAttribute(
+                typeof(XmlnsDefinitionAttribute));
+            Assert.Equal(typeof(Window).Namespace, attribute.ClrNamespace);
+            var type = resolver.Resolve(attribute.XmlNamespace, nameof(Window));
+
+            Assert.Equal(typeof(Window).FullName, type.FullName);
+        }
+    }
+}

--- a/XamlCompiler/AssemblyInfo.cs
+++ b/XamlCompiler/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("XamlCompiler.Tests")]

--- a/XamlCompiler/BinaryXamlWriter.cs
+++ b/XamlCompiler/BinaryXamlWriter.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.Diagnostics;
+using System.IO;
+using Mono.Cecil;
+using Portable.Xaml;
+
+namespace XamlCompiler
+{
+    public class BinaryXamlWriter : XamlWriter
+    {
+        private readonly ModuleDefinition _module;
+
+        private XamlType _baseType;
+        private TypeDefinition _currentType;
+
+        public BinaryXamlWriter(XamlSchemaContext context, string name, Version version)
+        {
+            SchemaContext = context;
+
+            var assemblyName = new AssemblyNameDefinition(name, version);
+            _module = CreateModule(assemblyName);
+        }
+
+        public void WriteAssembly(Stream output)
+        {
+            throw new NotImplementedException();
+        }
+
+        private static ModuleDefinition CreateModule(AssemblyNameDefinition assemblyName)
+        {
+            var assembly = AssemblyDefinition.CreateAssembly(
+                assemblyName,
+                assemblyName.Name,
+                ModuleKind.Dll);
+            return assembly.MainModule;
+        }
+
+        public override XamlSchemaContext SchemaContext { get; }
+
+        public override void WriteEndMember()
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void WriteEndObject()
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void WriteGetObject()
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void WriteNamespace(NamespaceDeclaration namespaceDeclaration)
+        {
+        }
+
+        public override void WriteStartMember(XamlMember xamlMember)
+        {
+            switch (xamlMember)
+            {
+                case var x when x == XamlLanguage.Class:
+                    Debug.Assert(_currentType == null);
+                    _currentType = new TypeDefinition("", "", TypeAttributes.Class);
+                    break;
+                default:
+                    throw new NotSupportedException($"XAML member {xamlMember} is not supported by the compiler");
+            }
+        }
+
+        public override void WriteStartObject(XamlType type)
+        {
+            Debug.Assert(_baseType == null);
+            _baseType = type;
+        }
+
+        public override void WriteValue(object value)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/XamlCompiler/BinaryXamlWriter.cs
+++ b/XamlCompiler/BinaryXamlWriter.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using Portable.Xaml;
 
@@ -8,10 +9,14 @@ namespace XamlCompiler
     {
         private readonly Compiler.XamlCompiler _compiler;
 
-        public BinaryXamlWriter(XamlSchemaContext context, string name, Version version)
+        public BinaryXamlWriter(
+            XamlSchemaContext context,
+            string name,
+            Version version,
+            IEnumerable<string> referencedAssemblyNames)
         {
             SchemaContext = context;
-            _compiler = new Compiler.XamlCompiler(name, version);
+            _compiler = new Compiler.XamlCompiler(name, version, referencedAssemblyNames);
         }
 
         public void WriteAssembly(Stream output) => _compiler.WriteAssembly(output);

--- a/XamlCompiler/Compiler/ObjectInfo.cs
+++ b/XamlCompiler/Compiler/ObjectInfo.cs
@@ -1,5 +1,8 @@
 ﻿using System;
+using System.Linq;
 using Mono.Cecil;
+using Mono.Cecil.Cil;
+using Mono.Cecil.Rocks;
 using Portable.Xaml;
 
 namespace XamlCompiler.Compiler
@@ -9,19 +12,35 @@ namespace XamlCompiler.Compiler
         public XamlType BaseType { get; set; }
         public string TypeName { get; set; }
 
-        public TypeDefinition CreateTypeDefinition()
+        public void AddTypeDefinition(ModuleDefinition module)
         {
             var baseType = BaseType.UnderlyingType;
-            var baseTypeAssembly = baseType.Assembly;
-            var baseTypeModule = ModuleDefinition.ReadModule(baseTypeAssembly.Location);
-            var baseTypeReference =
-                new TypeReference(baseType.Namespace, baseType.Name, baseTypeModule, baseTypeModule);
+            var baseTypeReference = module.ImportReference(baseType);
 
             var (@namespace, type) = ParseTypeName(TypeName);
             const TypeAttributes attributes = TypeAttributes.Public | TypeAttributes.Class;
             var definition = new TypeDefinition(@namespace, type, attributes, baseTypeReference);
+            AddConstructor(module, definition);
 
-            return definition;
+            module.Types.Add(definition);
+        }
+
+        private void AddConstructor(ModuleDefinition module, TypeDefinition definition)
+        {
+            const MethodAttributes attributes = MethodAttributes.Public
+                                                | MethodAttributes.HideBySig
+                                                | MethodAttributes.SpecialName
+                                                | MethodAttributes.RTSpecialName;
+            var ctor = new MethodDefinition(".ctor", attributes, module.TypeSystem.Void);
+            var ilProcessor = ctor.Body.GetILProcessor();
+
+            var baseTypeConstructor = definition.BaseType.Resolve().GetConstructors()
+                .Single(c => c.Parameters.Count == 0);
+            ilProcessor.Append(ilProcessor.Create(OpCodes.Ldarg_0));
+            ilProcessor.Append(ilProcessor.Create(OpCodes.Call, module.ImportReference(baseTypeConstructor)));
+            ilProcessor.Append(ilProcessor.Create(OpCodes.Ret));
+
+            definition.Methods.Add(ctor);
         }
 
         private (string @namespace, string type) ParseTypeName(string typeName)

--- a/XamlCompiler/Compiler/ObjectInfo.cs
+++ b/XamlCompiler/Compiler/ObjectInfo.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using Mono.Cecil;
+using Portable.Xaml;
+
+namespace XamlCompiler.Compiler
+{
+    internal class ObjectInfo
+    {
+        public XamlType BaseType { get; set; }
+        public string TypeName { get; set; }
+
+        public TypeDefinition CreateTypeDefinition()
+        {
+            var baseType = BaseType.UnderlyingType;
+            var baseTypeAssembly = baseType.Assembly;
+            var baseTypeModule = ModuleDefinition.ReadModule(baseTypeAssembly.Location);
+            var baseTypeReference =
+                new TypeReference(baseType.Namespace, baseType.Name, baseTypeModule, baseTypeModule);
+
+            var (@namespace, type) = ParseTypeName(TypeName);
+            const TypeAttributes attributes = TypeAttributes.Public | TypeAttributes.Class;
+            var definition = new TypeDefinition(@namespace, type, attributes, baseTypeReference);
+
+            return definition;
+        }
+
+        private (string @namespace, string type) ParseTypeName(string typeName)
+        {
+            if (typeName == null)
+            {
+                throw new NotSupportedException($"Type derived from {BaseType} has no name defined");
+            }
+
+            var index = typeName.IndexOf(".", StringComparison.InvariantCulture);
+            if (index == -1)
+            {
+                return (null, typeName);
+            }
+
+            return (typeName.Substring(0, index), typeName.Substring(index + 1));
+        }
+    }
+}

--- a/XamlCompiler/Compiler/ObjectInfo.cs
+++ b/XamlCompiler/Compiler/ObjectInfo.cs
@@ -9,18 +9,17 @@ namespace XamlCompiler.Compiler
 {
     internal class ObjectInfo
     {
-        public XamlType BaseType { get; }
+        public TypeReference BaseType { get; }
         public string TypeName { get; set; }
 
-        public ObjectInfo(XamlType baseType)
+        public ObjectInfo(TypeReference baseType)
         {
             BaseType = baseType;
         }
 
         public void AddTypeDefinition(ModuleDefinition module)
         {
-            var baseType = BaseType.UnderlyingType;
-            var baseTypeReference = module.ImportReference(baseType);
+            var baseTypeReference = module.ImportReference(BaseType);
 
             var (@namespace, type) = ParseTypeName(TypeName);
             const TypeAttributes attributes = TypeAttributes.Public | TypeAttributes.Class;

--- a/XamlCompiler/Compiler/ObjectInfo.cs
+++ b/XamlCompiler/Compiler/ObjectInfo.cs
@@ -54,7 +54,7 @@ namespace XamlCompiler.Compiler
                 throw new NotSupportedException($"Type derived from {BaseType} has no name defined");
             }
 
-            var index = typeName.IndexOf(".", StringComparison.InvariantCulture);
+            var index = typeName.LastIndexOf(".", StringComparison.InvariantCulture);
             if (index == -1)
             {
                 return (null, typeName);

--- a/XamlCompiler/Compiler/ObjectInfo.cs
+++ b/XamlCompiler/Compiler/ObjectInfo.cs
@@ -9,8 +9,13 @@ namespace XamlCompiler.Compiler
 {
     internal class ObjectInfo
     {
-        public XamlType BaseType { get; set; }
+        public XamlType BaseType { get; }
         public string TypeName { get; set; }
+
+        public ObjectInfo(XamlType baseType)
+        {
+            BaseType = baseType;
+        }
 
         public void AddTypeDefinition(ModuleDefinition module)
         {

--- a/XamlCompiler/Compiler/State.cs
+++ b/XamlCompiler/Compiler/State.cs
@@ -1,0 +1,10 @@
+﻿namespace XamlCompiler.Compiler
+{
+    internal enum State
+    {
+        Init,
+        End,
+        InsideObject,
+        InsideClassAttribute
+    }
+}

--- a/XamlCompiler/Compiler/XamlCompiler.cs
+++ b/XamlCompiler/Compiler/XamlCompiler.cs
@@ -1,0 +1,85 @@
+﻿using System;
+using System.IO;
+using System.Xml.XPath;
+using Mono.Cecil;
+using Portable.Xaml;
+using Stateless;
+
+namespace XamlCompiler.Compiler
+{
+    internal class XamlCompiler
+    {
+        private readonly AssemblyDefinition _assembly;
+        private readonly StateMachine<State, XamlParseTrigger> _stateMachine;
+
+        private readonly StateMachine<State, XamlParseTrigger>.TriggerWithParameters<XamlType> _objectStart;
+        private readonly StateMachine<State, XamlParseTrigger>.TriggerWithParameters<object> _attributeValue;
+
+        private ObjectInfo _currentObjectInfo;
+
+        public XamlCompiler(string assemblyName, Version assemblyVersion)
+        {
+            _assembly = AssemblyDefinition.CreateAssembly(
+                new AssemblyNameDefinition(assemblyName, assemblyVersion),
+                assemblyName,
+                ModuleKind.Dll);
+
+            _stateMachine = new StateMachine<State, XamlParseTrigger>(State.Init);
+            _objectStart = _stateMachine.SetTriggerParameters<XamlType>(XamlParseTrigger.ObjectStart);
+            _attributeValue = _stateMachine.SetTriggerParameters<object>(XamlParseTrigger.AttributeValue);
+
+            InitializeStateMachine();
+        }
+
+        private void InitializeStateMachine()
+        {
+            _stateMachine.Configure(State.Init)
+                .Permit(XamlParseTrigger.ObjectStart, State.InsideObject);
+
+            _stateMachine.Configure(State.End)
+                .OnEntry(GenerateType);
+
+            _stateMachine.Configure(State.InsideObject)
+                .OnEntryFrom(_objectStart, InitializeObject)
+                .OnEntryFrom(_attributeValue, SetAttributeValue)
+                .Ignore(XamlParseTrigger.AttributeValue)
+                .Permit(XamlParseTrigger.ClassAttribute, State.InsideClassAttribute)
+                .Permit(XamlParseTrigger.ObjectEnd, State.End);
+
+            _stateMachine.Configure(State.InsideClassAttribute)
+                .Permit(XamlParseTrigger.AttributeValue, State.InsideObject);
+        }
+
+        public void WriteAssembly(Stream output) => _assembly.Write(output);
+
+        public void OnStartObject(XamlType type) => _stateMachine.Fire(_objectStart, type);
+        public void OnClassAttribute() => _stateMachine.Fire(XamlParseTrigger.ClassAttribute);
+        public void OnAttributeValue(object value) => _stateMachine.Fire(_attributeValue, value);
+        public void OnEndObject() => _stateMachine.Fire(XamlParseTrigger.ObjectEnd);
+
+        private void InitializeObject(XamlType type) => _currentObjectInfo = new ObjectInfo
+        {
+            BaseType = type
+        };
+
+        private void SetAttributeValue(object value, StateMachine<State, XamlParseTrigger>.Transition transition)
+        {
+            switch (transition.Source)
+            {
+                case State.InsideClassAttribute:
+                    _currentObjectInfo.TypeName = (string) value;
+                    break;
+                default:
+                    throw new NotSupportedException(
+                        $"Invalid transition from {transition.Source} through {nameof(SetAttributeValue)}");
+            }
+        }
+
+        private void GenerateType()
+        {
+            var definition = _currentObjectInfo.CreateTypeDefinition();
+            _assembly.MainModule.Types.Add(definition);
+            _currentObjectInfo = null;
+        }
+    }
+}

--- a/XamlCompiler/Compiler/XamlCompiler.cs
+++ b/XamlCompiler/Compiler/XamlCompiler.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.IO;
-using System.Xml.XPath;
 using Mono.Cecil;
 using Portable.Xaml;
 using Stateless;
@@ -75,11 +74,6 @@ namespace XamlCompiler.Compiler
             }
         }
 
-        private void GenerateType()
-        {
-            var definition = _currentObjectInfo.CreateTypeDefinition();
-            _assembly.MainModule.Types.Add(definition);
-            _currentObjectInfo = null;
-        }
+        private void GenerateType() => _currentObjectInfo.AddTypeDefinition(_assembly.MainModule);
     }
 }

--- a/XamlCompiler/Compiler/XamlCompiler.cs
+++ b/XamlCompiler/Compiler/XamlCompiler.cs
@@ -56,10 +56,7 @@ namespace XamlCompiler.Compiler
         public void OnAttributeValue(object value) => _stateMachine.Fire(_attributeValue, value);
         public void OnEndObject() => _stateMachine.Fire(XamlParseTrigger.ObjectEnd);
 
-        private void InitializeObject(XamlType type) => _currentObjectInfo = new ObjectInfo
-        {
-            BaseType = type
-        };
+        private void InitializeObject(XamlType type) => _currentObjectInfo = new ObjectInfo(type);
 
         private void SetAttributeValue(object value, StateMachine<State, XamlParseTrigger>.Transition transition)
         {

--- a/XamlCompiler/Compiler/XamlParseTrigger.cs
+++ b/XamlCompiler/Compiler/XamlParseTrigger.cs
@@ -1,0 +1,10 @@
+﻿namespace XamlCompiler.Compiler
+{
+    internal enum XamlParseTrigger
+    {
+        ObjectStart,
+        ObjectEnd,
+        ClassAttribute,
+        AttributeValue
+    }
+}

--- a/XamlCompiler/Compiler/XamlTypeResolver.cs
+++ b/XamlCompiler/Compiler/XamlTypeResolver.cs
@@ -1,0 +1,43 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Mono.Cecil;
+using Portable.Xaml.Markup;
+
+namespace XamlCompiler.Compiler
+{
+    internal class XamlTypeResolver
+    {
+        private readonly Dictionary<string, XmlnsDefinition> _namespaces;
+
+        private XamlTypeResolver(IEnumerable<XmlnsDefinition> namespaces)
+        {
+            _namespaces = namespaces.ToDictionary(d => d.Xmlns);
+        }
+
+        public static XamlTypeResolver FromAssemblies(IEnumerable<string> paths)
+        {
+            var attributes = paths
+                .Select(AssemblyDefinition.ReadAssembly)
+                .SelectMany(assembly => assembly.CustomAttributes
+                    .Where(a => a.AttributeType.FullName == typeof(XmlnsDefinitionAttribute).FullName)
+                    .Select(a => new {Assembly = assembly, Attribute = a}));
+            var definitions = attributes.Select(x =>
+            {
+                var arguments = x.Attribute.ConstructorArguments;
+                var xmlns = (string) arguments[0].Value;
+                var ns = (string) arguments[1].Value;
+                return new XmlnsDefinition(xmlns, x.Assembly, ns);
+            });
+
+            return new XamlTypeResolver(definitions);
+        }
+
+        public TypeReference Resolve(string xmlns, string typeName)
+        {
+            // TODO[F]: Add type cache.
+            var definition = _namespaces[xmlns];
+            var types = definition.Assembly.Modules.SelectMany(m => m.Types);
+            return types.Single(t => t.FullName == $"{definition.Namespace}.{typeName}");
+        }
+    }
+}

--- a/XamlCompiler/Compiler/XmlnsDefinition.cs
+++ b/XamlCompiler/Compiler/XmlnsDefinition.cs
@@ -1,0 +1,18 @@
+﻿using Mono.Cecil;
+
+namespace XamlCompiler.Compiler
+{
+    internal class XmlnsDefinition
+    {
+        public string Xmlns { get; }
+        public AssemblyDefinition Assembly { get; }
+        public string Namespace { get; }
+
+        public XmlnsDefinition(string xmlns, AssemblyDefinition assembly, string ns)
+        {
+            Xmlns = xmlns;
+            Assembly = assembly;
+            Namespace = ns;
+        }
+    }
+}

--- a/XamlCompiler/XamlCompiler.csproj
+++ b/XamlCompiler/XamlCompiler.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.0</TargetFramework>
@@ -6,5 +6,6 @@
   <ItemGroup>
     <PackageReference Include="Mono.Cecil" Version="0.10.0-beta7" />
     <PackageReference Include="Portable.Xaml" Version="0.17.0" />
+    <PackageReference Include="Stateless" Version="4.0.0" />
   </ItemGroup>
 </Project>

--- a/XamlCompiler/XamlCompiler.csproj
+++ b/XamlCompiler/XamlCompiler.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Mono.Cecil" Version="0.10.0-beta7" />
     <PackageReference Include="Portable.Xaml" Version="0.17.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This project aims to create a XAML compiler to CLR assemblies (to be later reused in AvaloniaUI).

In this PR, I've created the initial project architecture and API (it also already generates a valid assembly from the simplest XAML specimen I was able to write).

### Open questions

1. I think that the internals are messy a bit: I had to use mutable methods a lot. Probably could be improved?
2. @kekekeks, is it okay that we load the assemblies used by XAML into the compiler app domain? I wasn't able to determine whether Portable.Xaml supports any kind of XAML loading without `XamlSchemaContext` filled with preloaded assemblies. Should I use Portable.Xaml anyway, or does Avalonia switches to some other library now?
3. Not sure if it's worth to use `StateMachine` library here.

### TODO

- [x] add more unit tests
- [x] don't load the referenced assemblies into the compiler appdomain